### PR TITLE
Extract guides out fo type-hints.

### DIFF
--- a/riposte/exceptions.py
+++ b/riposte/exceptions.py
@@ -1,6 +1,24 @@
+from typing import Callable
+
+from .printer import Palette
+
+
 class RiposteException(Exception):
     pass
 
 
 class CommandError(RiposteException):
     pass
+
+
+class ValidationError(RiposteException):
+    def __init__(self, value: str, validator: Callable):
+        self.value = value
+        self.validator = validator
+
+    def __str__(self):
+        return (
+            f"ValidationError: Can't validate "
+            f"{Palette.BOLD.format(self.value)} using "
+            f"{Palette.BOLD.format(self.validator.__name__)} validator"
+        )

--- a/riposte/guides.py
+++ b/riposte/guides.py
@@ -1,0 +1,39 @@
+import ast
+from typing import Any, AnyStr, Callable, Dict, Tuple
+
+from riposte.exceptions import ValidationError
+
+
+def literal(value: str) -> Any:
+    try:
+        return ast.literal_eval(value)
+    except Exception:
+        raise ValidationError(value, literal)
+
+
+def encode(value: str) -> Any:
+    try:
+        return value.encode()
+    except Exception:
+        raise ValidationError(value, encode)
+
+
+def get_guides(annotation) -> Tuple[Callable]:
+    """ Based on given annotation get set of guides. """
+
+    if annotation is AnyStr:
+        return ()
+    elif issubclass(annotation, str):
+        return ()
+    elif issubclass(annotation, bytes):
+        return (encode,)
+    else:
+        return (literal,)
+
+
+def extract_guides(func: Callable) -> Dict[str, Tuple[Callable]]:
+    """ Extract guides out of type-annotations. """
+    return {
+        arg: get_guides(annotation)
+        for arg, annotation in func.__annotations__.items()
+    }

--- a/riposte/printer/__init__.py
+++ b/riposte/printer/__init__.py
@@ -1,1 +1,1 @@
-from .hue import Hue  # noqa
+from .palette import Palette  # noqa

--- a/riposte/printer/palette.py
+++ b/riposte/printer/palette.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class Hue(Enum):
+class Palette(Enum):
     GREY = 30
     RED = 31
     GREEN = 32
@@ -11,5 +11,7 @@ class Hue(Enum):
     CYAN = 36
     WHITE = 37
 
-    def color(self, obj: str):
+    BOLD = 1
+
+    def format(self, obj: str):
         return f"\033[{self.value}m{obj}\033[0m"

--- a/riposte/riposte.py
+++ b/riposte/riposte.py
@@ -124,15 +124,13 @@ class Riposte(PrinterMixin):
         self,
         name: str,
         description: str = "",
-        validators: Dict[str, Iterable[Callable]] = None,
+        guides: Dict[str, Iterable[Callable]] = None,
     ) -> Callable:
         """ Decorator for bounding command with handling function. """
 
         def wrapper(func: Callable):
             if name not in self._commands:
-                self._commands[name] = Command(
-                    name, func, description, validators
-                )
+                self._commands[name] = Command(name, func, description, guides)
             else:
                 raise RiposteException(f"'{name}' command already exists.")
             return func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,9 @@ def repl(history_file):
 
 @pytest.fixture
 def foo_command(repl: Riposte):
-    repl.command(name="foo")(Mock(name="function_handling_foo"))
+    repl.command(name="foo")(
+        Mock(name="function_handling_foo", __annotations__={})
+    )
     return repl._commands["foo"]
 
 
@@ -26,6 +28,6 @@ def history_file(tmpdir):
 def command():
     return Command(
         name="foo",
-        func=Mock(name="mocked_handling_function"),
+        func=Mock(name="mocked_handling_function", __annotations__={}),
         description="foo description",
     )

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,26 +1,25 @@
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
 
+from riposte.command import Command
 from riposte.exceptions import CommandError
 
 
 def test_execute(command):
     args = (1, 2, 3)
-    mocked_apply_validators = command._apply_validators = Mock(
-        return_value=args
-    )
+    mocked_apply_guides = command._apply_guides = mock.Mock(return_value=args)
 
     command.execute(*args)
 
-    mocked_apply_validators.assert_called_once_with(*args)
+    mocked_apply_guides.assert_called_once_with(*args)
     command._func.assert_called_once_with(*args)
 
 
 def test_complete(command):
     args = (1, 2, 3)
     kwargs = {"scoo": "bee", "doo": "bee"}
-    command._completer_function = Mock()
+    command._completer_function = mock.Mock()
 
     command.complete(*args, **kwargs)
 
@@ -28,7 +27,7 @@ def test_complete(command):
 
 
 def test_attach_completer(command):
-    completer_function = Mock()
+    completer_function = mock.Mock()
 
     command.attach_completer(completer_function)
 
@@ -36,32 +35,69 @@ def test_attach_completer(command):
 
 
 def test_attach_completer_already_attached(command):
-    command._completer_function = Mock()
+    command._completer_function = mock.Mock()
 
     with pytest.raises(CommandError):
-        command.attach_completer(Mock())
+        command.attach_completer(mock.Mock())
 
 
-def test_apply_validators(command):
-    validator_alpha = Mock(name="alpha")
-    validator_bravo = Mock(name="bravo")
+@mock.patch("riposte.command.extract_guides")
+def test_command_setup_guides_validate(mocked_extract_guides):
+
+    with mock.patch.object(
+        Command, "_validate_guides"
+    ) as mocked_validate_guides:
+
+        Command("foo", mock.Mock(), "description")
+
+        mocked_validate_guides.assert_called_once_with()
+
+
+@mock.patch(
+    "riposte.command.extract_guides", return_value={"foo": (mock.Mock(),)}
+)
+def test_command_setup_guides_extract(mocked_extract_guides):
+    func = mock.Mock()
+
+    command = Command("foo", func, "description")
+
+    mocked_extract_guides.assert_called_once_with(func)
+    assert command._guides == mocked_extract_guides.return_value
+
+
+@mock.patch(
+    "riposte.command.extract_guides", return_value={"foo": (mock.Mock(),)}
+)
+def test_command_setup_guides_update(mocked_extract_guides):
+    func = mock.Mock()
+    guides = {"foo": [str], "bar": [str]}
+
+    command = Command("foo", func, "description", guides=guides)
+
+    mocked_extract_guides.assert_called_once_with(func)
+    assert command._guides == guides
+
+
+def test_apply_guides(command):
+    validator_alpha = mock.Mock(name="alpha")
+    validator_bravo = mock.Mock(name="bravo")
 
     command._func = lambda x: None
-    command._validators = {"x": [validator_alpha, validator_bravo]}
+    command._guides = {"x": [validator_alpha, validator_bravo]}
 
-    assert command._apply_validators(1) == [validator_bravo.return_value]
+    assert command._apply_guides(1) == [validator_bravo.return_value]
 
     validator_alpha.assert_called_once_with(1)
     validator_bravo.assert_called_once_with(validator_alpha.return_value)
 
 
-def test_apply_validators_no_validators(command):
+def test_apply_guides_no_guides(command):
     command._func = lambda x, y: None
-    assert command._apply_validators(1, 2) == [1, 2]
+    assert command._apply_guides(1, 2) == [1, 2]
 
 
-@pytest.mark.parametrize("validators", (1, "str", (int), [2.0]))
-def test_validate_validators(command, validators):
-    command._validators = {"foo": validators}
+@pytest.mark.parametrize("guides", (1, "str", (int), [2.0]))
+def test_validate_guides(command, guides):
+    command._guides = {"foo": guides}
     with pytest.raises(CommandError):
-        command._validate_validators()
+        command._validate_guides()

--- a/tests/test_guides.py
+++ b/tests/test_guides.py
@@ -1,0 +1,69 @@
+from typing import AnyStr, Dict, List, Set
+from unittest import mock
+
+import pytest
+
+from riposte import guides
+from riposte.exceptions import ValidationError
+
+
+@mock.patch("riposte.guides.ast")
+def test_literal(mocked_ast):
+    value = "foo"
+
+    processed_value = guides.literal(value)
+
+    mocked_ast.literal_eval.assert_called_once_with(value)
+    assert processed_value == mocked_ast.literal_eval.return_value
+
+
+@mock.patch("riposte.guides.ast")
+def test_literal_exception(mocked_ast):
+    mocked_ast.literal_eval.side_effect = TypeError
+
+    with pytest.raises(ValidationError):
+        guides.literal("foo")
+
+
+def test_encode():
+    mocked_value = mock.Mock()
+
+    processed_value = guides.encode(mocked_value)
+
+    mocked_value.encode.assert_called_once_with()
+    assert processed_value == mocked_value.encode.return_value
+
+
+def test_encode_exception():
+    mocked_value = mock.Mock()
+    mocked_value.encode.side_effect = UnicodeEncodeError
+
+    with pytest.raises(ValidationError):
+        guides.encode(mocked_value)
+
+
+@pytest.mark.parametrize(
+    ("type_", "return_value"),
+    (
+        (AnyStr, tuple()),
+        (str, tuple()),
+        (bytes, (guides.encode,)),
+        (int, (guides.literal,)),
+        (Dict, (guides.literal,)),
+        (List, (guides.literal,)),
+        (Set, (guides.literal,)),
+    ),
+)
+def test_get_guides(type_, return_value):
+    assert guides.get_guides(type_) == return_value
+
+
+@mock.patch("riposte.guides.get_guides")
+def test_extract_guides(mocked_get_guides):
+    type_hint = int
+    func = mock.Mock(__annotations__={"foo": type_hint})
+
+    extracted_guides = guides.extract_guides(func)
+
+    mocked_get_guides.assert_called_once_with(type_hint)
+    assert extracted_guides == {"foo": mocked_get_guides.return_value}

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from riposte.printer import Hue
+from riposte.printer import Palette
 from riposte.printer.mixins import PrinterBaseMixin, PrinterMixin
 from riposte.printer.thread import PrintResource
 
@@ -24,9 +24,11 @@ def printer_mixin():
         yield mixin
 
 
-def test_hue():
+def test_palette():
     value = "scoobeedoo"
-    assert Hue.RED.color(value) == f"\033[{Hue.RED.value}m{value}\033[0m"
+    assert (
+        Palette.RED.format(value) == f"\033[{Palette.RED.value}m{value}\033[0m"
+    )
 
 
 def test_printer_mixin_info(printer_mixin, args, kwargs):


### PR DESCRIPTION
## Extract guides out of type-hints. 
- Rename `validators` to `guides`
- Extract guides out of type-hints.
- If for given command no guides was explicitly defined by user use
`guides.literal` as default guide for any type-hint except for `str`.

## Rename `Hue` to `Palette`
- Rename `Hue` to `Palette`
- Add `BOLD` formatting option