### PR TITLE
 Validate arguments provided by user

### DIFF
--- a/riposte/exceptions.py
+++ b/riposte/exceptions.py
@@ -11,14 +11,14 @@ class CommandError(RiposteException):
     pass
 
 
-class ValidationError(RiposteException):
-    def __init__(self, value: str, validator: Callable):
+class GuideError(RiposteException):
+    def __init__(self, value: str, guide: Callable):
         self.value = value
-        self.validator = validator
+        self.guide = guide
 
     def __str__(self):
         return (
-            f"ValidationError: Can't validate "
-            f"{Palette.BOLD.format(self.value)} using "
-            f"{Palette.BOLD.format(self.validator.__name__)} validator"
+            f"ValidationError: Can't apply "
+            f"{Palette.BOLD.format(self.guide.__name__)} guide "
+            f"to value {Palette.BOLD.format(self.value)}"
         )

--- a/riposte/guides.py
+++ b/riposte/guides.py
@@ -1,25 +1,25 @@
 import ast
 from typing import Any, AnyStr, Callable, Dict, Tuple
 
-from riposte.exceptions import ValidationError
+from riposte.exceptions import GuideError
 
 
 def literal(value: str) -> Any:
     try:
         return ast.literal_eval(value)
     except Exception:
-        raise ValidationError(value, literal)
+        raise GuideError(value, literal)
 
 
 def encode(value: str) -> Any:
     try:
         return value.encode()
     except Exception:
-        raise ValidationError(value, encode)
+        raise GuideError(value, encode)
 
 
 def get_guides(annotation) -> Tuple[Callable]:
-    """ Based on given annotation get set of guides. """
+    """ Based on given annotation get chain of guides. """
 
     if annotation is AnyStr:
         return ()

--- a/tests/test_guides.py
+++ b/tests/test_guides.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from riposte import guides
-from riposte.exceptions import ValidationError
+from riposte.exceptions import GuideError
 
 
 @mock.patch("riposte.guides.ast")
@@ -21,7 +21,7 @@ def test_literal(mocked_ast):
 def test_literal_exception(mocked_ast):
     mocked_ast.literal_eval.side_effect = TypeError
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(GuideError):
         guides.literal("foo")
 
 
@@ -38,7 +38,7 @@ def test_encode_exception():
     mocked_value = mock.Mock()
     mocked_value.encode.side_effect = UnicodeEncodeError
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(GuideError):
         guides.encode(mocked_value)
 
 

--- a/tests/test_riposte.py
+++ b/tests/test_riposte.py
@@ -54,8 +54,8 @@ def test_command_duplicated_command(repl: Riposte, foo_command):
         ("scoo bee doo", ["scoo", "bee", "doo"]),
         ("  scoo  bee  doo  ", ["scoo", "bee", "doo"]),
         ("\tscoo\tbee\tdoo\n", ["scoo", "bee", "doo"]),
-        ("", [""]),
-        ("  \t\n", [""]),
+        ("", []),
+        ("  \t\n", []),
     ],
 )
 def test_parse_line(raw_line, parsed_line, repl: Riposte):


### PR DESCRIPTION
## Validate arguments provided by user
- Check whether arguments provided by user via `input()` match `_func` signature. Feeding already validated arguments list to `_apply_guides` allow to simplify its code.
## Rename `ValidationError` so name better reflects its purpose.
- Rename `ValidationError` so name better reflects its purpose.
## Change behavior of `_parse_line` to return empty list. 
- Return empty list instead of preparing artificial response to accommodate instant star unpacking.