### PR TITLE
Check if readline.__doc__ is None

### DIFF
--- a/riposte/riposte.py
+++ b/riposte/riposte.py
@@ -13,7 +13,7 @@ from .printer.thread import PrinterThread
 
 
 def is_libedit():
-    return readline.__doc__ and 'libedit' in readline.__doc__
+    return readline.__doc__ and "libedit" in readline.__doc__
 
 
 class Riposte(PrinterMixin):

--- a/riposte/riposte.py
+++ b/riposte/riposte.py
@@ -13,7 +13,7 @@ from .printer.thread import PrinterThread
 
 
 def is_libedit():
-    return "libedit" in readline.__doc__
+    return readline.__doc__ and 'libedit' in readline.__doc__
 
 
 class Riposte(PrinterMixin):


### PR DESCRIPTION
## Changes
In certain Windows installs, readline.__doc__ is None. Added a check before iterating.
## Issue
Improving Windows compatibility #9 
## Related pull request
Add compatibility for Windows #14 
## Inspiration
[Add handling for Windows "readline.__doc__ is NoneType" error](https://github.com/clarkperkins/click-shell/pull/11)